### PR TITLE
[WIP] Handles

### DIFF
--- a/src/main/java/tc/oc/minecraft/api/command/CommandSender.java
+++ b/src/main/java/tc/oc/minecraft/api/command/CommandSender.java
@@ -2,8 +2,13 @@ package tc.oc.minecraft.api.command;
 
 import net.md_5.bungee.api.chat.BaseComponent;
 import tc.oc.minecraft.api.permissions.Permissible;
+import tc.oc.reference.Handle;
+import tc.oc.reference.Handleable;
 
-public interface CommandSender extends Permissible {
+public interface CommandSender extends Permissible, Handleable {
+
+    @Override
+    Handle<? extends CommandSender> handle();
 
     /**
      * Get the unique name of this command sender.

--- a/src/main/java/tc/oc/minecraft/api/entity/Player.java
+++ b/src/main/java/tc/oc/minecraft/api/entity/Player.java
@@ -6,8 +6,12 @@ import java.util.UUID;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.BaseComponent;
 import tc.oc.minecraft.api.command.CommandSender;
+import tc.oc.reference.Handle;
 
 public interface Player extends CommandSender {
+
+    @Override
+    Handle<? extends Player> handle();
 
     /**
      * Gets this player's display name.
@@ -56,4 +60,6 @@ public interface Player extends CommandSender {
      * Get the Minecraft protocol version in use by this player's connection
      */
     int getProtocolVersion();
+
+
 }

--- a/src/main/java/tc/oc/minecraft/api/plugin/Plugin.java
+++ b/src/main/java/tc/oc/minecraft/api/plugin/Plugin.java
@@ -9,8 +9,14 @@ import tc.oc.minecraft.api.event.EventRegistry;
 import tc.oc.exception.ExceptionHandler;
 import tc.oc.minecraft.api.server.Server;
 import tc.oc.minecraft.api.logging.Loggable;
+import tc.oc.reference.Handle;
+import tc.oc.reference.Handleable;
 
-public interface Plugin extends Loggable {
+public interface Plugin extends Loggable, Handleable {
+
+    @Override
+    Handle<? extends Plugin> handle();
+
     /**
      * Return metadata about this plugin
      */

--- a/src/main/java/tc/oc/minecraft/api/server/LocalServer.java
+++ b/src/main/java/tc/oc/minecraft/api/server/LocalServer.java
@@ -5,11 +5,15 @@ import java.util.Set;
 import tc.oc.minecraft.api.command.ConsoleCommandSender;
 import tc.oc.minecraft.api.logging.Loggable;
 import tc.oc.minecraft.api.plugin.PluginFinder;
+import tc.oc.reference.Handle;
 
 /**
  * The local server i.e. the one hosting plugins
  */
 public interface LocalServer extends Loggable, Server {
+
+    @Override
+    Handle<? extends LocalServer> handle();
 
     PluginFinder getPluginFinder();
 

--- a/src/main/java/tc/oc/minecraft/api/server/Server.java
+++ b/src/main/java/tc/oc/minecraft/api/server/Server.java
@@ -4,11 +4,16 @@ import java.util.Collection;
 import java.util.UUID;
 
 import tc.oc.minecraft.api.entity.Player;
+import tc.oc.reference.Handle;
+import tc.oc.reference.Handleable;
 
 /**
  * A Minecraft server or proxy, local or remote
  */
-public interface Server {
+public interface Server extends Handleable {
+
+    @Override
+    Handle<? extends Server> handle();
 
     /**
      * Return all players currently connected.

--- a/src/main/java/tc/oc/proxy/Proxies.java
+++ b/src/main/java/tc/oc/proxy/Proxies.java
@@ -1,0 +1,42 @@
+package tc.oc.proxy;
+
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class Proxies {
+
+    public static <T> T forwarding(Class<T> type, Supplier<? extends T> supplier) {
+        return forwarding(type.getClassLoader(), type, supplier);
+    }
+
+    public static <T> T forwarding(ClassLoader loader, Class<T> type, Supplier<? extends T> supplier) {
+        return (T) Proxy.newProxyInstance(
+            loader,
+            new Class<?>[]{type},
+            (proxy, method, args) -> method.invoke(supplier.get(), args)
+        );
+    }
+
+    public static <T> T forwarding(ClassLoader loader, Class<T> type, Supplier<? extends T> supplier, Map<Class<?>, ?> extensions) {
+        final Class[] inters = new Class[extensions.size() + 1];
+        int i = 0;
+        for(Class inter : extensions.keySet()) {
+            inters[i++] = inter;
+        }
+        inters[i] = type;
+
+        return (T) Proxy.newProxyInstance(
+            loader,
+            inters,
+            (proxy, method, args) -> {
+                for(Class<?> inter : extensions.keySet()) {
+                    if(method.getDeclaringClass().isAssignableFrom(inter)) {
+                        return method.invoke(extensions.get(inter), args);
+                    }
+                }
+                return method.invoke(supplier.get(), args);
+            }
+        );
+    }
+}

--- a/src/main/java/tc/oc/proxy/ProxyBuilder.java
+++ b/src/main/java/tc/oc/proxy/ProxyBuilder.java
@@ -1,0 +1,150 @@
+package tc.oc.proxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+public class ProxyBuilder {
+
+    private static final List<Method> IDENTITY_METHODS;
+
+    static {
+        try {
+            IDENTITY_METHODS = Arrays.asList(
+                Object.class.getDeclaredMethod("equals", Object.class),
+                Object.class.getDeclaredMethod("hashCode")
+            );
+
+        } catch(NoSuchMethodException e) {
+            throw new NoSuchMethodError(e.getMessage());
+        }
+    }
+
+    private ClassLoader loader = null;
+    private final Map<Method, InvocationHandler> methodHandlers = new LinkedHashMap<>();
+    private final Map<Class<?>, InvocationHandler> typeHandlers = new LinkedHashMap<>();
+
+    public ProxyBuilder loadFrom(ClassLoader loader) {
+        this.loader = loader;
+        return this;
+    }
+
+    public HandlerBuilder delegate(Method method) {
+        return new HandlerBuilder<>(to -> methodHandlers.put(method, to));
+    }
+
+    public HandlerBuilder delegate(Iterable<Method> methods) {
+        return new HandlerBuilder<>(to -> {
+            for(Method method : methods) {
+                methodHandlers.put(method, to);
+            }
+        });
+    }
+
+    public <T> HandlerBuilder<T> delegate(Class<T> type) {
+        return new HandlerBuilder<>(to -> typeHandlers.put(type, to));
+    }
+
+    public HandlerBuilder delegateIdentity() {
+        return delegate(IDENTITY_METHODS);
+    }
+
+    private void validate() {
+        for(Class<?> type : typeHandlers.keySet()) {
+            if(!type.isInterface() && !type.equals(Object.class)) {
+                throw new IllegalArgumentException("Cannot proxy non-interface type " + type.getName());
+            }
+        }
+        for(Method method : methodHandlers.keySet()) {
+            if(typeHandlers.keySet().stream().noneMatch(method.getDeclaringClass()::isAssignableFrom)) {
+                throw new IllegalArgumentException("Method " + method.getName() + " is not present in any implemented interfaces");
+            }
+        }
+    }
+
+    public Object newProxyInstance() {
+        validate();
+        return Proxy.newProxyInstance(
+            loader != null ? loader : Thread.currentThread().getContextClassLoader(),
+            typeHandlers.keySet().toArray(new Class<?>[typeHandlers.size()]),
+            new Invoker(methodHandlers, typeHandlers)
+        );
+    }
+
+    public class HandlerBuilder<T> {
+        private Consumer<InvocationHandler> consumer;
+
+        private HandlerBuilder(Consumer<InvocationHandler> consumer) {
+            this.consumer = consumer;
+        }
+
+        public ProxyBuilder to(InvocationHandler handler) {
+            if(consumer == null) {
+                throw new IllegalStateException();
+            }
+            consumer.accept(handler);
+            consumer = null;
+            return ProxyBuilder.this;
+        }
+
+        public ProxyBuilder toInstance(T to) {
+            return to((proxy, m, args) -> m.invoke(to, args));
+        }
+
+        public ProxyBuilder toSupplier(Supplier<T> to) {
+            return to((proxy, method, args) -> method.invoke(to.get(), args));
+        }
+    }
+
+    private static class Invoker implements InvocationHandler {
+
+        private final LoadingCache<Method, InvocationHandler> handlers;
+
+        private Invoker(Map<Method, InvocationHandler> methods, Map<Class<?>, InvocationHandler> types) {
+            this.handlers = CacheBuilder.newBuilder().build(new CacheLoader<Method, InvocationHandler>() {
+                @Override
+                public InvocationHandler load(Method method) throws Exception {
+                    // Look for an exact method
+                    InvocationHandler handler = methods.get(method);
+                    if(handler != null) return handler;
+
+                    // Look for the exact declaring interface of the method
+                    // If Object is delegated, that will be caught here
+                    final Class<?> decl = method.getDeclaringClass();
+                    handler = types.get(decl);
+                    if(handler != null) return handler;
+
+                    // Any Object methods not handled above are delegated to the Invoker itself
+                    if(decl.equals(Object.class)) {
+                        return (proxy, method1, args) -> method1.invoke(Invoker.this, args);
+                    }
+
+                    // If the method is not from Object, look for an interface that inherits it
+                    for(Map.Entry<Class<?>, InvocationHandler> entry : types.entrySet()) {
+                        if(decl.isAssignableFrom(entry.getKey())) {
+                            return entry.getValue();
+                        }
+                    }
+
+                    // Give up ¯\_(ツ)_/¯
+                    throw new NoSuchMethodError(method.getName());
+                }
+            });
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            return handlers.get(method).invoke(proxy, method, args);
+        }
+    }
+}

--- a/src/main/java/tc/oc/reference/Handle.java
+++ b/src/main/java/tc/oc/reference/Handle.java
@@ -1,0 +1,332 @@
+package tc.oc.reference;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.inject.Provider;
+
+import tc.oc.proxy.ProxyBuilder;
+import tc.oc.util.Lazy;
+
+/**
+ * A lightweight object that can quickly retrieve some other object of type {@link T},
+ * without necessarily holding a strong reference to it. This is similar to a {@link WeakReference},
+ * but more flexible, because the mechanism for (de)referencing can be implemented
+ * by the creator of the handle. Various useful bells and whistles are also provided.
+ *
+ * There are several ways to retrieve the referent object:
+ *
+ *   {@link #getIfPresent()} is self-explanatory
+ *
+ *   {@link #get()} returns the referent if available, otherwise it throws a
+ *   {@link HandleUnavailableException}. Any exception thrown by the dereferencing code is wrapped
+ *   in a {@link HandleDereferenceException}, so that it can be reliably distinguished.
+ *
+ *   {@link #proxy()} tries to return a proxy for the actual referent that routes all
+ *   method calls through the handle. This only works if the handle was constructed with
+ *   an explicit interface type. Otherwise, {@link #proxy()} just calls {@link #get()}.
+ */
+public abstract class Handle<T> implements Supplier<T>, Provider<T> {
+
+    private final @Nullable Class<T> type;
+    private final @Nullable Object key;
+    private final Lazy<T> proxy;
+
+    private Handle(@Nullable Class<T> type, @Nullable Object key) {
+        if(type != null && !type.isInterface()) {
+            throw new IllegalArgumentException("Handle type " + type.getName() + " is not an interface");
+        }
+
+        this.type = type;
+        this.key = key;
+
+        proxy = Lazy.from(() -> (T) new ProxyBuilder()
+            .loadFrom(type.getClassLoader())
+            .delegateIdentity().toSupplier(this::key)
+            .delegate(Handleable.class).toInstance(new Handleable() {
+                @Override public Handle<?> handle() { return Handle.this; }
+            })
+            .delegate(type).toSupplier(this)
+            .newProxyInstance()
+        );
+    }
+
+    public boolean hasKey() {
+        return key != null;
+    }
+
+    public Object key() throws HandleUnavailableException {
+        return key != null ? key : get();
+    }
+
+    public boolean hasProxy() {
+        return type != null;
+    }
+
+    public T proxy() {
+        return type != null ? proxy.get() : get();
+    }
+
+    @Override
+    public int hashCode() {
+        return key().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || (
+            obj instanceof Handle &&
+            this.key().equals(((Handle) obj).key())
+        );
+    }
+
+    public boolean isPresent() {
+        return getIfPresent().isPresent();
+    }
+
+    public abstract Optional<T> getIfPresent();
+
+    @Override
+    public T get() throws HandleUnavailableException, HandleDereferenceException {
+        final Optional<T> opt;
+        try { opt = getIfPresent(); }
+        catch(Throwable ex) { throw HandleDereferenceException.causedBy(ex); }
+        return opt.orElseThrow(HandleUnavailableException::new);
+    }
+
+    public Handle<T> ifPresent(Consumer<? super T> consumer) {
+        if(isPresent()) {
+            consumer.accept(get());
+        }
+        return this;
+    }
+
+    public Handle<T> ifAbsent(Runnable runnable) {
+        if(!isPresent()) {
+            runnable.run();
+        }
+        return this;
+    }
+
+    public T orElse(T t) {
+        return isPresent() ? get() : t;
+    }
+
+    public T orElseGet(Supplier<? extends T> supplier) {
+        return isPresent() ? get() : supplier.get();
+    }
+
+    public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+        if(isPresent()) return get();
+        throw exceptionSupplier.get();
+    }
+
+    public Handle<T> filter(Predicate<? super T> predicate) {
+        return new Handle<T>(type, key) {
+            @Override
+            public Optional<T> getIfPresent() {
+                return Handle.this.getIfPresent().filter(predicate);
+            }
+        };
+    }
+
+    public <U> Handle<U> map(Function<? super T, ? extends U> mapper) {
+        return map(null, mapper);
+    }
+
+    public <U> Handle<U> map(@Nullable Object key, Function<? super T, ? extends U> mapper) {
+        return map(null, key, mapper);
+    }
+
+    public <U> Handle<U> map(@Nullable Class<U> type, @Nullable Object key, Function<? super T, ? extends U> mapper) {
+        return new Handle<U>(type, key) {
+            @Override
+            public Optional<U> getIfPresent() {
+                return Handle.this.getIfPresent().flatMap(u -> {
+                    try {
+                        return Optional.of(mapper.apply(u));
+                    } catch(HandleUnavailableException ex) {
+                        return Optional.empty();
+                    }
+                });
+            }
+
+            @Override
+            public U get() throws HandleUnavailableException {
+                return mapper.apply(Handle.this.get());
+            }
+        };
+    }
+
+    public <U> Handle<U> flatMap(Function<? super T, Optional<U>> mapper) {
+        return flatMap(null, mapper);
+    }
+
+    public <U> Handle<U> flatMap(@Nullable Object key, Function<? super T, Optional<U>> mapper) {
+        return flatMap(null, key, mapper);
+    }
+
+    public <U> Handle<U> flatMap(@Nullable Class<U> type, @Nullable Object key, Function<? super T, Optional<U>> mapper) {
+        return new Handle<U>(type, key) {
+            @Override
+            public Optional<U> getIfPresent() {
+                return Handle.this.getIfPresent().flatMap(mapper);
+            }
+        };
+    }
+
+    public static <T> Handle<T> empty() {
+        return empty(null);
+    }
+
+    public static <T> Handle<T> empty(@Nullable Object key) {
+        return empty(null, key);
+    }
+
+    public static <T> Handle<T> empty(@Nullable Class<T> type, @Nullable Object key) {
+        return new Handle<T>(type, key) {
+            @Override
+            public boolean isPresent() {
+                return false;
+            }
+
+            @Override
+            public Optional getIfPresent() {
+                return Optional.empty();
+            }
+
+            @Override
+            public T get() {
+                throw new HandleUnavailableException();
+            }
+        };
+    }
+
+    public static <T> Handle<T> ofInstance(T instance) {
+        return ofInstance(null, instance);
+    }
+
+    public static <T> Handle<T> ofInstance(@Nullable Class<T> type, T instance) {
+        final Optional<T> opt = Optional.of(instance);
+        return new Handle<T>(type, instance) {
+            @Override
+            public boolean isPresent() {
+                return true;
+            }
+
+            @Override
+            public Optional<T> getIfPresent() {
+                return opt;
+            }
+
+            @Override
+            public T get() {
+                return instance;
+            }
+        };
+    }
+
+    public static <T> Handle<T> ofWeakInstance(T instance) {
+        return ofWeakInstance(null, instance);
+    }
+
+    public static <T> Handle<T> ofWeakInstance(@Nullable Object key, T instance) {
+        return ofWeakInstance(null, key, instance);
+    }
+
+    public static <T> Handle<T> ofWeakInstance(@Nullable Class<T> type, @Nullable Object key, T instance) {
+        return ofReference(type, key, new WeakReference<>(instance));
+    }
+
+    public static <T> Handle<T> ofReference(Reference<T> reference) {
+        return ofReference(null, reference);
+    }
+
+    public static <T> Handle<T> ofReference(@Nullable Object key, Reference<T> reference) {
+        return ofReference(null, key, reference);
+    }
+
+    public static <T> Handle<T> ofReference(@Nullable Class<T> type, @Nullable Object key, Reference<T> reference) {
+        return ofNullableSupplier(type, key, reference::get);
+    }
+
+    public static <T> Handle<T> ofSupplier(Supplier<T> supplier) {
+        return ofSupplier(null, supplier);
+    }
+
+    public static <T> Handle<T> ofSupplier(@Nullable Object key, Supplier<T> supplier) {
+        return ofSupplier(null, key, supplier);
+    }
+
+    public static <T> Handle<T> ofSupplier(@Nullable Class<T> type, @Nullable Object key, Supplier<T> supplier) {
+        return new Handle<T>(type, key) {
+            @Override
+            public Optional<T> getIfPresent() {
+                try {
+                    return Optional.of(get());
+                } catch(HandleUnavailableException ex) {
+                    return Optional.empty();
+                }
+            }
+
+            @Override
+            public T get() throws HandleUnavailableException {
+                return supplier.get();
+            }
+        };
+    }
+
+    public static <T> Handle<T> ofOptionalSupplier(Supplier<Optional<T>> supplier) {
+        return ofOptionalSupplier(null, supplier);
+    }
+
+    public static <T> Handle<T> ofOptionalSupplier(@Nullable Object key, Supplier<Optional<T>> supplier) {
+        return ofOptionalSupplier(null, key, supplier);
+    }
+
+    public static <T> Handle<T> ofOptionalSupplier(@Nullable Class<T> type, @Nullable Object key, Supplier<Optional<T>> supplier) {
+        return new Handle<T>(type, key) {
+            @Override
+            public Optional<T> getIfPresent() {
+                return supplier.get();
+            }
+        };
+    }
+
+    public static <T> Handle<T> ofNullableSupplier(Supplier<T> supplier) {
+        return ofNullableSupplier(null, supplier);
+    }
+
+    public static <T> Handle<T> ofNullableSupplier(@Nullable Object key, Supplier<T> supplier) {
+        return ofNullableSupplier(null, key, supplier);
+    }
+
+    public static <T> Handle<T> ofNullableSupplier(@Nullable Class<T> type, @Nullable Object key, Supplier<T> supplier) {
+        return new Handle<T>(type, key) {
+            @Override
+            public boolean isPresent() {
+                return null != supplier.get();
+            }
+
+            @Override
+            public Optional<T> getIfPresent() {
+                return Optional.ofNullable(supplier.get());
+            }
+
+            @Override
+            public T get() {
+                final T instance;
+                try { instance = supplier.get(); }
+                catch(Throwable ex) { throw HandleDereferenceException.causedBy(ex); }
+                if(instance == null) throw new HandleUnavailableException();
+                return instance;
+            }
+        };
+    }
+}
+

--- a/src/main/java/tc/oc/reference/HandleDereferenceException.java
+++ b/src/main/java/tc/oc/reference/HandleDereferenceException.java
@@ -1,0 +1,13 @@
+package tc.oc.reference;
+
+public class HandleDereferenceException extends RuntimeException {
+
+    public HandleDereferenceException(Throwable cause) {
+        super("Exception while dereferencing", cause);
+    }
+
+    public static HandleDereferenceException causedBy(Throwable cause) {
+        return cause instanceof HandleDereferenceException ? (HandleDereferenceException) cause
+                                                           : new HandleDereferenceException(cause);
+    }
+}

--- a/src/main/java/tc/oc/reference/HandleUnavailableException.java
+++ b/src/main/java/tc/oc/reference/HandleUnavailableException.java
@@ -1,0 +1,12 @@
+package tc.oc.reference;
+
+public class HandleUnavailableException extends RuntimeException {
+
+    public HandleUnavailableException() {
+        this("Handle is not available");
+    }
+
+    public HandleUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/tc/oc/reference/Handleable.java
+++ b/src/main/java/tc/oc/reference/Handleable.java
@@ -1,0 +1,42 @@
+package tc.oc.reference;
+
+/**
+ * An object that can supply a {@link Handle} for itself.
+ *
+ * When creating a handle that uses an anonymous class or lambda to retrieve the referent,
+ * be careful not to capture the referent itself. For example, this is bad:
+ *
+ * <code>
+ *     class Thing implements Handleable {
+ *         int id;
+ *
+ *         @Override
+ *         public Handle<? extends Thing> handle() {
+ *             return Handle.ofSupplier(() -> Thing.find(this.id))
+ *         }
+ *     }
+ * </code>
+ *
+ * The lambda captures a reference to the Thing by accessing an instance field,
+ * and so the Handle effectively leaks the instance. To ensure this doesn't happen,
+ * you can create the reference in a static method that doesn't have any access
+ * to the referent:
+ *
+ * <code>
+ *         private static Handle<? extends Thing> makeHandle(int id) {
+ *             return Handle.ofSupplier(() -> Thing.find(id));
+ *         }
+ *
+ *         @Override
+ *         public Handle<? extends Thing> handle() {
+ *             return makeHandle(this.id);
+ *         }
+ * </code>
+ *
+ */
+public interface Handleable {
+
+    default Handle<?> handle() {
+        return Handle.ofWeakInstance(this);
+    }
+}

--- a/src/main/java/tc/oc/util/Lazy.java
+++ b/src/main/java/tc/oc/util/Lazy.java
@@ -1,0 +1,43 @@
+package tc.oc.util;
+
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+public class Lazy<T> implements Supplier<T>, Provider<T> {
+
+    public static <T> Lazy<T> from(Supplier<T> supplier) {
+        return new Lazy<>(supplier);
+    }
+
+    private @Nullable Supplier<T> supplier;
+    private @Nullable T instance;
+
+    @Inject Lazy(Provider<T> provider) {
+        this.supplier = provider::get;
+    }
+
+    Lazy(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    @Override
+    public T get() {
+        if(instance != null) return instance;
+        synchronized(this) {
+            if(instance != null) return instance;
+            if(supplier == null) {
+                throw new IllegalStateException("Circular instantiation of lazy object");
+            }
+            final Supplier<T> temp = supplier;
+            supplier = null;
+            instance = temp.get();
+            if(instance == null) {
+                throw new NullPointerException("Lazy object cannot have a null value");
+            }
+            return instance;
+        }
+    }
+}
+


### PR DESCRIPTION
This is a generalization of the idea behind some recent [SportBukkit](https://github.com/OvercastNetwork/SportBukkit/commit/a99432df0a169475b50c1784e1d0868fd396efa7) [changes](https://github.com/OvercastNetwork/SportBukkit/commit/7d8f516b430ef5f5575793831bde026642bbd863)

Objects that are prone to leakage, such as `World`, `Entity`, etc, can provide a `Handle` to themselves, a lightweight object that knows how to retrieve the object, but does not hold a strong reference to it. Trying to access the object beyond its natural lifespan throws an exception. `Handle`s to the same object compare equal to each other, and this can be determined without dereferencing the object. A handle can also provide a dynamic proxy for the object that delegates method calls through the handle.

Objects can provide `Handle`s through the `Handleable` interface. This uses a `WeakReference` by default, but this has the limitation that any leak of the object prevents the release of all `Handle`s. Things like `World` or `Entity` would implement `Handle`s using their `UUID`.

This needs a bit more work, and some implementation in SportBukkit and BungeeCord.